### PR TITLE
docs: sync README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ uv add <library>
 ```
 
 ## Testing
-
+**TODO**
 
 ## Linting
-
+**TODO**
 
 ## Deployment
-
+**TODO**
 
 # License
 MIT 

--- a/README.md
+++ b/README.md
@@ -12,21 +12,31 @@ To install, follow the official installation guide: https://github.com/astral-sh
 
 ## Setup
 
-1. Clone the repo
+1. Clone the Repo
 
-cd <working_directory>
-
+```
 git clone https://github.com/RMI/web-api-poc
+cd web-api-poc
+```
 
-2. Activate the virtual environment
+2. Create and Activate the Virtual Environment
+```
+uv venv .venv
+source .venv/bin/activate # macOS/Linux
+```
 
-source .venv/bin/activate
+3. Install Dependencies
+```
+uv sync
+```
 
 # Running the API
 
 Locally serve the Fast API with:
 
+```
 uv run main.py
+```
 
 The API will be accessible at http://127.0.0.1:5000.
 
@@ -36,7 +46,9 @@ The API will be accessible at http://127.0.0.1:5000.
 
 Dependencies are managed using uv . New dependencies can be added using:
 
+```
 uv add <library>
+```
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@ uv add <library>
 **TODO**
 
 # License
-MIT 
+ This project is licensed under the [MIT License](LICENSE.txt) 


### PR DESCRIPTION
In this PR, I add a few missing set-up steps to the `README.md` to get a fresh user up and running with this repo. 

I confirm that, after freshly cloning the repository, following all updated steps in the README, and spinning up a local server using `uv run main.py`, I can successfully `curl` the default "Hello World" endpoint:

![Screenshot 2025-02-18 at 20 38 49](https://github.com/user-attachments/assets/b56952e6-f35a-4546-8ad3-6cd74775f19e)

Note: While I was there, I also added a few NIT elements to the README (e.g. `TODOs` and a link to the `LICENSE`).