### PR TITLE
feat: gains linting via the`black` code formatter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,32 @@
+name: Linting
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  black:
+    name: Run Black Code Formatter
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ".python-version"
+
+      - name: Install Black
+        run: uv pip install black
+
+      - name: Run Black Check
+        run: uv run black --check .
+

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,8 +24,8 @@ jobs:
         with:
           python-version-file: ".python-version"
 
-      - name: Install Black
-        run: uv pip install black
+      - name: Install the project
+        run: uv sync --only-dev
 
       - name: Run Black Check
         run: uv run black --check .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ".python-version"
+          python-version-file: ".python-version"
 
       - name: Install Black
         run: uv pip install black

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Linting
+name: Lint
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
 
 jobs:
   black:
-    name: Run Black Code Formatter
+    name: Run black code formatter
     runs-on: ubuntu-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,15 @@ uv add --dev <library>
 ```
 
 ## Linting
-**TODO**
+
+This project follows the [black](https://github.com/psf/black) code formatting standard.
+Local code can easily be linted by calling:
+```
+black path/to/file.py # to lint a single file
+black . # to lint the entire directory
+```
+
+Code should be linted prior to opening a pull request in this repository. 
 
 ## Deployment
 **TODO**

--- a/app/main.py
+++ b/app/main.py
@@ -4,10 +4,12 @@ import uvicorn
 
 app = FastAPI()
 
+
 class HealthCheck(BaseModel):
     """Response model to validate and return when performing a health check."""
 
     status: str = "OK"
+
 
 @app.get("/")
 def root():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "black>=25.1.0",
     "httpx>=0.28.1",
     "pytest>=8.3.4",
     "pytest-asyncio>=0.25.3",

--- a/src/main.py
+++ b/src/main.py
@@ -10,10 +10,10 @@ app = FastAPI()
 def root():
     return {"Hello": "World"}
 
+
 app.include_router(health_router)
 app.include_router(data_output)
 
 
 if __name__ == "__main__":
     uvicorn.run("main:app", host="127.0.0.1", port=5000, log_level="info")
-    

--- a/src/models/health.py
+++ b/src/models/health.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
 
+
 class HealthCheck(BaseModel):
     """Response model to validate and return when performing a health check."""
 

--- a/src/models/outputs.py
+++ b/src/models/outputs.py
@@ -1,7 +1,8 @@
 from pydantic import BaseModel
 
+
 #  create Pydantic model for mtcars dataset
-class mtcar(BaseModel): 
+class mtcar(BaseModel):
     model: str
     mpg: float
     cyl: int
@@ -14,4 +15,3 @@ class mtcar(BaseModel):
     am: bool
     gear: int
     carb: int
-

--- a/src/routers/health.py
+++ b/src/routers/health.py
@@ -2,8 +2,8 @@ from fastapi import APIRouter, status
 from models.health import HealthCheck
 
 
-
 health_router = APIRouter()
+
 
 @health_router.get(
     "/health",
@@ -12,7 +12,7 @@ health_router = APIRouter()
     response_description="Return HTTP Status Code 200 (OK)",
     status_code=status.HTTP_200_OK,
     response_model=HealthCheck,
-) 
+)
 async def get_health() -> HealthCheck:
     """
     ## Perform a Health Check

--- a/src/routers/mtcars.py
+++ b/src/routers/mtcars.py
@@ -8,32 +8,31 @@ data_output = APIRouter()
 
 
 @data_output.get(
-    # api endpoint for complete mtcars dataset 
+    # api endpoint for complete mtcars dataset
     "/api/dataset",
     tags=["data"],
     summary="Return mtcars dataset ",
     response_description="mtcars dataset in json",
     status_code=status.HTTP_200_OK,
     response_model=mtcar,
-) 
+)
 async def get_full_mtcars() -> mtcar:
     # convert MTCARS dict into JSON response
     MTCARS_json = jsonable_encoder(MTCARS)
     return JSONResponse(content=MTCARS_json)
 
 
-
 @data_output.get(
-    # api endpoint for individual mtcars items  
+    # api endpoint for individual mtcars items
     "/api/{item_id}",
     tags=["data"],
     summary="Return mtcars item",
     response_description="mtcars item in json",
     status_code=status.HTTP_200_OK,
     response_model=mtcar,
-    )
+)
 async def read_item(item_id: str):
     if item_id not in MTCARS:
         raise HTTPException(status_code=404, detail="Item not found")
-    
+
     return MTCARS[item_id]

--- a/src/services/mtcars.py
+++ b/src/services/mtcars.py
@@ -4,7 +4,7 @@ from importlib import resources
 
 def csv_to_dict(csv_path):
     mtcars = {}
-    with open(csv_path, 'r') as file:
+    with open(csv_path, "r") as file:
         csv_reader = csv.DictReader(file)
         for row in csv_reader:
             # Assuming the first column is a unique key
@@ -13,5 +13,5 @@ def csv_to_dict(csv_path):
     return mtcars
 
 
-with resources.path('data', 'mtcars.csv') as mtcars_path:
+with resources.path("data", "mtcars.csv") as mtcars_path:
     MTCARS = csv_to_dict(mtcars_path)

--- a/uv.lock
+++ b/uv.lock
@@ -25,6 +25,30 @@ wheels = [
 ]
 
 [[package]]
+name = "black"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "mypy-extensions" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/49/26a7b0f3f35da4b5a65f081943b7bcd22d7002f5f0fb8098ec1ff21cb6ef/black-25.1.0.tar.gz", hash = "sha256:33496d5cd1222ad73391352b4ae8da15253c5de89b93a80b3e2c8d9a19ec2666", size = 649449 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/71/3fe4741df7adf015ad8dfa082dd36c94ca86bb21f25608eb247b4afb15b2/black-25.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4b60580e829091e6f9238c848ea6750efed72140b91b048770b64e74fe04908b", size = 1650988 },
+    { url = "https://files.pythonhosted.org/packages/13/f3/89aac8a83d73937ccd39bbe8fc6ac8860c11cfa0af5b1c96d081facac844/black-25.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e2978f6df243b155ef5fa7e558a43037c3079093ed5d10fd84c43900f2d8ecc", size = 1453985 },
+    { url = "https://files.pythonhosted.org/packages/6f/22/b99efca33f1f3a1d2552c714b1e1b5ae92efac6c43e790ad539a163d1754/black-25.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b48735872ec535027d979e8dcb20bf4f70b5ac75a8ea99f127c106a7d7aba9f", size = 1783816 },
+    { url = "https://files.pythonhosted.org/packages/18/7e/a27c3ad3822b6f2e0e00d63d58ff6299a99a5b3aee69fa77cd4b0076b261/black-25.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:ea0213189960bda9cf99be5b8c8ce66bb054af5e9e861249cd23471bd7b0b3ba", size = 1440860 },
+    { url = "https://files.pythonhosted.org/packages/98/87/0edf98916640efa5d0696e1abb0a8357b52e69e82322628f25bf14d263d1/black-25.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8f0b18a02996a836cc9c9c78e5babec10930862827b1b724ddfe98ccf2f2fe4f", size = 1650673 },
+    { url = "https://files.pythonhosted.org/packages/52/e5/f7bf17207cf87fa6e9b676576749c6b6ed0d70f179a3d812c997870291c3/black-25.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:afebb7098bfbc70037a053b91ae8437c3857482d3a690fefc03e9ff7aa9a5fd3", size = 1453190 },
+    { url = "https://files.pythonhosted.org/packages/e3/ee/adda3d46d4a9120772fae6de454c8495603c37c4c3b9c60f25b1ab6401fe/black-25.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:030b9759066a4ee5e5aca28c3c77f9c64789cdd4de8ac1df642c40b708be6171", size = 1782926 },
+    { url = "https://files.pythonhosted.org/packages/cc/64/94eb5f45dcb997d2082f097a3944cfc7fe87e071907f677e80788a2d7b7a/black-25.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:a22f402b410566e2d1c950708c77ebf5ebd5d0d88a6a2e87c86d9fb48afa0d18", size = 1442613 },
+    { url = "https://files.pythonhosted.org/packages/09/71/54e999902aed72baf26bca0d50781b01838251a462612966e9fc4891eadd/black-25.1.0-py3-none-any.whl", hash = "sha256:95e8176dae143ba9097f351d174fdaf0ccd29efb414b362ae3fd72bf0f710717", size = 207646 },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.1.31"
 source = { registry = "https://pypi.org/simple" }
@@ -124,12 +148,39 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy-extensions"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/a4/1ab47638b92648243faf97a5aeb6ea83059cc3624972ab6b8d2316078d3f/mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782", size = 4433 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d", size = 4695 },
+]
+
+[[package]]
 name = "packaging"
 version = "24.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451 },
+]
+
+[[package]]
+name = "pathspec"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191 },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.3.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/fc/128cc9cb8f03208bdbf93d3aa862e16d376844a14f9a0ce5cf4507372de4/platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907", size = 21302 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/a6/bc1012356d8ece4d66dd75c4b9fc6c1f6650ddd5991e421177d9f8f671be/platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb", size = 18439 },
 ]
 
 [[package]]
@@ -276,6 +327,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "black" },
     { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -290,6 +342,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "black", specifier = ">=25.1.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-asyncio", specifier = ">=0.25.3" },


### PR DESCRIPTION
In this PR, I facilitate automated linting in this repository. Given this is the first time linting is enforced, a lot of files had to be edited to satisfy the linter. In future PRs, this will be less of a problem. 

ℹ️ I chose to go with the `black` linter: https://github.com/psf/black
This linter seems to be very opinionated and relatively strict while offering many helpful implementation tools. 

I opted for this approach because, in general, I don't particularly care that much about _what_ precise linting rules we follow and am very happy to outsource that decision to people who have thought about it more than I have.
Bikeshedding on a linter feels like a huge waste of time.

📦 Gains a development dependency on the `black` library.
🚧 Gains GH action to run linting on every PR.

Towards #3 