### PR TITLE
feat: root endpoint now redirects to documentation

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from fastapi.responses import RedirectResponse
 from routers.health import health_router
 from routers.mtcars import data_output
 import uvicorn
@@ -7,9 +8,9 @@ app = FastAPI()
 
 
 @app.get("/")
-def root():
-    return {"Hello": "World"}
-
+async def redirect():
+    response = RedirectResponse(url="/docs")
+    return response
 
 app.include_router(health_router)
 app.include_router(data_output)

--- a/src/main.py
+++ b/src/main.py
@@ -12,6 +12,7 @@ async def redirect():
     response = RedirectResponse(url="/docs")
     return response
 
+
 app.include_router(health_router)
 app.include_router(data_output)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -26,3 +26,15 @@ def test_dataset_model():
     assert isinstance(mtcars, list)
     for mtcar_data in mtcars:
         mtcar(**mtcar_data)
+
+
+def test_root_redirects():
+    response = client.get("/", follow_redirects=False)
+    assert response.status_code == 307  # Temporary Redirect
+    assert response.headers["location"] == "/docs"
+
+
+def test_root_redirect_follows():
+    response = client.get("/", follow_redirects=True)
+    assert response.status_code == 200
+    assert "Swagger UI" in response.text


### PR DESCRIPTION
## Previous behavior:
`/` endpoint would respond with "Hello World".

## New behavior:
`/` endpoint redirects to the Swagger documentation.

This is likely a more useful default functionality overall. 

No related issue.
