### PR TITLE
fix: CI now fails as expected when tests fail

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,9 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: "Run tests"
-        run: uv run pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=src tests/ | tee pytest-coverage.txt
+        run: |
+          set -o pipefail
+          uv run pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=src tests/ | tee pytest-coverage.txt
 
       - name: "Pytest coverage comment"
         uses: MishaKav/pytest-coverage-comment@main


### PR DESCRIPTION
This PR ensures that the CI step running tests correctly fails when tests fail. Previously, the output of `pytest` was piped to `tee` to capture coverage and test output in a file (`pytest-coverage.txt`), but this caused the step to always succeed—even when tests failed—because `tee` was masking the `pytest` exit code.

# Fix
Added `set -o pipefail` to the script running tests. This ensures the CI step returns the exit code of `pytest`, not just `tee`.

## Before:
```bash
uv run pytest ... | tee pytest-coverage.txt
# This would always return 0 (success)
```

## After:
``` bash
set -o pipefail
uv run pytest ... | tee pytest-coverage.txt
# Correctly fails if pytest fails
```

This change preserves output logging for debugging and ensures test failures are properly caught by CI.