### PR TITLE
fix: integration test failures due to `main.py` moving out of `src`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ uv sync
 ### Locally serve the Fast API with:
 
 ```
-uv run src/main.py
+uv run main.py
 ```
 
 ### Run Fast API in docker container with: 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,13 @@ dev = [
     "pytest-asyncio>=0.25.3",
     "pytest-cov>=6.0.0",
 ]
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-pythonpath = src
+pythonpath = .

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 pythonpath = .
+asyncio_default_fixture_loop_scope = function

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,10 +2,6 @@ from fastapi.testclient import TestClient
 from main import app
 from models.outputs import mtcar
 from services.auth import get_api_key
-import os
-
-API_KEY = os.environ.get("API_KEY", "test_api_key")
-headers = {"X-API-Key": API_KEY}
 
 
 def override_get_api_key():
@@ -24,14 +20,14 @@ def test_health_check():
 
 
 def test_element_model():
-    response = client.get("/api/HondaCivic", headers=headers)
+    response = client.get("/api/HondaCivic")
     assert response.status_code == 200
     # Validate single mtcars instance against mtcar model
     mtcar.model_validate(response.json())
 
 
 def test_dataset_model():
-    response = client.get("/api/dataset", headers=headers)
+    response = client.get("/api/dataset")
     assert response.status_code == 200
     # Validate that full dataset is a list and each list item is mtcar
     mtcars = response.json()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,10 +1,18 @@
 from fastapi.testclient import TestClient
 from main import app
 from models.outputs import mtcar
+from services.auth import get_api_key
 import os
 
-API_KEY = os.environ.get("API_KEY")
+API_KEY = os.environ.get("API_KEY", "test_api_key")
 headers = {"X-API-Key": API_KEY}
+
+
+def override_get_api_key():
+    return True
+
+
+app.dependency_overrides[get_api_key] = override_get_api_key
 
 client = TestClient(app)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,10 @@
 from fastapi.testclient import TestClient
 from main import app
 from models.outputs import mtcar
+import os
+
+API_KEY = os.environ.get("API_KEY")
+headers = {"X-API-Key": API_KEY}
 
 client = TestClient(app)
 
@@ -12,14 +16,14 @@ def test_health_check():
 
 
 def test_element_model():
-    response = client.get("/api/HondaCivic")
+    response = client.get("/api/HondaCivic", headers=headers)
     assert response.status_code == 200
     # Validate single mtcars instance against mtcar model
     mtcar.model_validate(response.json())
 
 
 def test_dataset_model():
-    response = client.get("/api/dataset")
+    response = client.get("/api/dataset", headers=headers)
     assert response.status_code == 200
     # Validate that full dataset is a list and each list item is mtcar
     mtcars = response.json()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.12"
 
 [[package]]
@@ -391,7 +390,7 @@ wheels = [
 [[package]]
 name = "web-api-poc"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "dotenv" },
     { name = "fastapi" },


### PR DESCRIPTION
#40 quietly introduced a bug causing integration tests to fail. This is because integration tests require running the `main.py` entry point, and this file was adjusted and moved.

We didn't catch these failures due to a separate bug in CI, where `tee` was causing Test failures to go unnoticed (fixed in #46). 

In this PR I:
- Set-up the `web-api-poc` with build instructions, allowing for installation as a Python library
- Change the pytest scope to be the root directory (as opposed to `src`) allowing it to run integration tests on `main.py` which is no longer in `src`
- Fix integration tests to require the newly added Authentication layer (see #45)
- Update documentation

This should now result in all tests passing. Once this merges, I will open #46 for review.
