### PR TITLE
fix(docker): grant write permissions for package installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN uv sync --frozen --no-install-project
 # Copy project source code
 COPY src/ ./src/
 
+RUN chmod -R a+w /app/src /app/.venv
+
 # Copy main entrypoint
 COPY main.py ./main.py
 


### PR DESCRIPTION
This PR fixes a permissions issue that prevented the editable installation of the `web-api-poc` Python package.

The bug was likely introduced in #48 when switching to a non-root user inside the Docker container. As a result, the container lacked write access to `/app/src` and `/app/.venv`, causing `uv sync` to fail.

This fix adds write permissions recursively to those directories during the image build process to ensure successful package installation.
