### PR TITLE
ci: add workflow to build, health-check, and push Docker image

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -1,0 +1,78 @@
+name: "Docker: Build & Push"
+
+on:
+  schedule:
+    - cron: '0 3 * * *'  # Nightly at 3 AM UTC
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build-test-and-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write  # Needed to push to GHCR
+
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and start container (as backing service)
+        run: |
+          docker compose up --build -d
+
+      - name: Wait for container to be ready
+        run: |
+          for i in {1..10}; do
+            echo "Checking health... attempt $i"
+            status=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:80/health || true)
+            if [ "$status" == "200" ]; then
+              echo "✅ Health check passed!"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "❌ Health check failed after retries."
+          docker compose logs
+          exit 1
+
+      - name: Tag image
+        id: tag
+        run: |
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            echo "tag=nightly" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            echo "tag=latest" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "tag=pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=unknown" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and tag image
+        run: |
+          docker build -t $IMAGE_NAME:${{ steps.tag.outputs.tag }} .
+
+      - name: Push to GHCR
+        run: |
+          docker push $IMAGE_NAME:${{ steps.tag.outputs.tag }}
+
+      - name: Clean up
+        run: docker compose down
+

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -33,6 +33,25 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Prepare Environment
+        id: prepare-environment
+        env:
+          registry: "ghcr.io"
+          image_name: ${{ github.repository_owner }}/web-api-poc
+        run: |
+          NOW="$(date -u +'%Y%m%dT%H%M%SZ')"
+          echo "now=$NOW" >> $GITHUB_OUTPUT
+          echo "$NOW"
+
+          registry_image=$(
+            echo "$registry/$image_name" | \
+            tr '[:upper:]' '[:lower:]' \
+          )
+          REGISTRY_IMAGE=${registry_image}
+          echo "registry-image=$REGISTRY_IMAGE"
+          echo "registry-image=$REGISTRY_IMAGE" >> $GITHUB_OUTPUT
+
 
       - name: Build and start container (as backing service)
         run: |
@@ -68,11 +87,11 @@ jobs:
 
       - name: Build and tag image
         run: |
-          docker build -t $IMAGE_NAME:${{ steps.tag.outputs.tag }} .
+          docker build -t ${{ steps.prepare-environment.outputs.registry-image }}:${{ steps.tag.outputs.tag }} .
 
       - name: Push to GHCR
         run: |
-          docker push $IMAGE_NAME:${{ steps.tag.outputs.tag }}
+          docker push ${{ steps.prepare-environment.outputs.registry-image }:${{ steps.tag.outputs.tag }}
 
       - name: Clean up
         run: docker compose down

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Push to GHCR
         run: |
-          docker push ${{ steps.prepare-environment.outputs.registry-image }:${{ steps.tag.outputs.tag }}
+          docker push ${{ steps.prepare-environment.outputs.registry-image }}:${{ steps.tag.outputs.tag }}
 
       - name: Clean up
         run: docker compose down

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -1,4 +1,4 @@
-name: "Docker: Build & Push"
+name: "Docker"
 
 on:
   schedule:
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build-test-and-push:
+    name: "Build and push"
     runs-on: ubuntu-latest
 
     permissions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN uv sync --frozen --no-install-project
 # Copy project source code
 COPY src/ ./src/
 
+RUN chmod -R a+w /app/src /app/.venv
+
 # Copy main entrypoint
 COPY main.py ./main.py
 


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that builds, verifies, and publishes the Docker image for the `web-api-poc` app.

🔁 Triggers:
- Nightly via CRON (3 AM UTC)
- On pull requests
- On pushes to the `main` branch

⚙️ Workflow steps:
1. Builds the Docker image, and serves it as a backing service using `docker compose up --build`.
2. Starts the container and checks the `/health` endpoint.
3. If the health check returns HTTP 200 OK:
   - Tags and pushes the image to GitHub Container Registry (ghcr.io).
   - Tags follow a consistent scheme:
     - `nightly` for CRON jobs
     - `latest` for pushes to `main`
     - `pr-<number>` for PR builds

This ensures the image is always tested before being published, and that tags reflect the context of each build.
